### PR TITLE
Remove the Unlink=off option

### DIFF
--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -10,7 +10,7 @@ module(load="imuxsock" # needs to be done just once
     SysSock.RateLimit.Interval="0" # turn off rate limiting
     SysSock.Unlink="on")           # unlink when done
 # create and read log messages from /rsyslog/imuxsock
-input(type="imuxsock" Socket="/rsyslog/imuxsock" CreatePath="on" Unlink="off")
+input(type="imuxsock" Socket="/rsyslog/imuxsock" CreatePath="on")
 
 #$ModLoad imklog   # provides kernel logging support
 #$ModLoad immark  # provides --MARK-- message capability


### PR DESCRIPTION
This option means rsyslog won't delete the `/rsyslog/imuxsock` when
it shuts down, but rsyslog always expects to be able to create the
socket when starting (unless it has been told by systemd about an
existing socket), so fails to start if the socket already exists.

By removing this option, rsyslog is able to take care creation and
deletion of the socket itself.

Fixes #1
