### PR TITLE
Change the imuxsock location

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The `rsyslog` container created from `redmatter/rsyslog` docker image is configu
 
     docker run -d --name syslog -v /tmp/rsyslog:/var/run/rsyslog/dev redmatter/rsyslog
 
-The command above will start up the rsyslog daemon in `syslog` container which will result in creating the socket.
+The command above will start up the rsyslog daemon in `syslog` container which will result in the socket being created at `/tmp/rsyslog/log`.
 
 To share this socket to another container, you need to volume mount just the socket as `/dev/log`.
 
@@ -42,13 +42,13 @@ To work around this, the client container can mount the parent directory of the 
 
 # What next?
 
-Configure rsyslog to forward messages to another server / service. The image comes with elasticsearch module which can be used to formward messages to ELK stack.
+Configure rsyslog to forward messages to another server / service. The image comes with elasticsearch module which can be used to forward messages to ELK stack.
 
 **IMPORTANT:** For heavy loads or production deployments, you must configure it to not log to disk (`/var/log/messages`).
 
 # Caveats
 
- - You will loose the hostname information of the logging application. The hostname that appears in the log will always be that of the `syslog` container, which is a meaningles hash created by docker (the container ID). You may consider [rsyslog property replacer](http://www.rsyslog.com/doc/v8-stable/configuration/property_replacer.html) to help you with this.
+ - You will lose the hostname information of the logging application. The hostname that appears in the log will always be that of the `syslog` container, which is a meaningless hash created by docker (the container ID). You may consider [rsyslog property replacer](http://www.rsyslog.com/doc/v8-stable/configuration/property_replacer.html) to help you with this.
  - The `redmatter/rsyslog` is by default configured to log to `/var/log/messages`. This can get out of hand if you use it as is in heavy load production environments, as there is no `logrotate` functionality. Have a look at [`forward.conf.example`](forward.conf.example) in order to configure rsyslog to forward all messages to another host. You may also use [`elasticsearch` module](http://www.rsyslog.com/doc/v8-stable/configuration/modules/omelasticsearch.html) to forward messages to ELK stack (though it will make logstash redundant).
 
 # Bedtime reading

--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ The `redmatter/rsyslog` docker image helps you with this solution.
 
 If you understand `docker-compose` YAML, then go ahead and have a look at [`docker-compose.example.yml`](docker-compose.example.yml).
 
-The `rsyslog` container created from `redmatter/rsyslog` docker image is configured to listen on an additional socket within the container at `/rsyslog/imuxsock`. In order to expose this socket to other containers, you need to pass in a path on the host as volume for `/rsyslog`.
+The `rsyslog` container created from `redmatter/rsyslog` docker image is configured to listen on an additional socket within the container at `/var/run/rsyslog/dev/log`.  In order to expose this socket to other containers, you need to ensure this container's `/var/run/rsyslog/dev` directory is mounted via a volume.
 
-    docker run -d --name syslog -v /tmp/rsyslog:/rsyslog redmatter/rsyslog
+    docker run -d --name syslog -v /tmp/rsyslog:/var/run/rsyslog/dev redmatter/rsyslog
 
 The command above will start up the rsyslog daemon in `syslog` container which will result in creating the socket.
 
 To share this socket to another container, you need to volume mount just the socket as `/dev/log`.
 
-    docker run -it --rm -v /tmp/rsyslog/imuxsock:/dev/log busybox
+    docker run -it --rm -v /tmp/rsyslog/log:/dev/log busybox
 
 Now, if you log some messages from the `busybox` container, you will be able to see these logged into `/var/log/messages` on the `syslog` container.
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile.debian
     volumes:
-      - /tmp/rsyslog-dev:/rsyslog
+      - /tmp/rsyslog-dev:/var/run/rsyslog/dev
 
   logging-app:
     build: "example-logging-app"
@@ -16,6 +16,6 @@ services:
       # make sure syslog container starts up before the app
       - syslog
     volumes:
-      - /tmp/rsyslog-dev/imuxsock:/dev/log
+      - /tmp/rsyslog-dev/log:/dev/log
 
 # vim: tabstop=2 shiftwidth=2 expandtab:

--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -9,8 +9,8 @@ module(load="imuxsock" # needs to be done just once
     SysSock.FlowControl="off"      # no blocking when queues fillup
     SysSock.RateLimit.Interval="0" # turn off rate limiting
     SysSock.Unlink="on")           # unlink when done
-# create and read log messages from /rsyslog/imuxsock
-input(type="imuxsock" Socket="/rsyslog/imuxsock" CreatePath="on")
+# create and read log messages from /var/run/rsyslog/dev/log
+input(type="imuxsock" Socket="/var/run/rsyslog/dev/log" CreatePath="on")
 
 #$ModLoad imklog   # provides kernel logging support
 #$ModLoad immark  # provides --MARK-- message capability


### PR DESCRIPTION
This is so that the socket name can be a little more familiar for client containers mounting in the parent directory, rather than mounting the socket directly.

This comes as part of a general effort to support usage of this image by mounting the parent directory of the socket into the client container and symlinking from `/dev/log`, rather than mounting the socket itself, as this can cause issues if containers don't start in the correct order.  Credit for the symlink approach goes to https://github.com/helderco/docker-rsyslog.
